### PR TITLE
Show goals according to status

### DIFF
--- a/app/controllers/daily_goals_controller.rb
+++ b/app/controllers/daily_goals_controller.rb
@@ -11,7 +11,7 @@ class DailyGoalsController < ApplicationController
 
   def new
     @daily_goal = current_user.daily_goals.build
-    @daily_goal.goal_date = view_context.today
+    @daily_goal.goal_date = Time.current.to_date
   end
 
   def edit

--- a/app/controllers/monthly_goals_controller.rb
+++ b/app/controllers/monthly_goals_controller.rb
@@ -18,7 +18,7 @@ class MonthlyGoalsController < ApplicationController
 
   def create
     @monthly_goal = current_user.monthly_goals.build(monthly_goal_params)
-    @monthly_goal.season = view_context.current_season
+    @monthly_goal.season = view_context.season_start(Time.current.to_date)
 
     respond_to do |format|
       if @monthly_goal.save

--- a/app/controllers/weekly_goals_controller.rb
+++ b/app/controllers/weekly_goals_controller.rb
@@ -11,7 +11,7 @@ class WeeklyGoalsController < ApplicationController
 
   def new
     @weekly_goal = current_user.weekly_goals.build
-    @weekly_goal.weeknum = view_context.absolute_weeknum
+    @weekly_goal.weeknum = Time.current.to_date.beginning_of_week
   end
 
   def edit

--- a/app/helpers/daily_goals_helper.rb
+++ b/app/helpers/daily_goals_helper.rb
@@ -1,13 +1,9 @@
 module DailyGoalsHelper
-  def no_daily_goal? (user)
-    DailyGoal.of(user).count.zero?
+  def no_daily_goal? (user, date=Time.current.to_date)
+    DailyGoal.of(user, date).count.zero?
   end
 
-  def daily_goal (user)
-    DailyGoal.of(user).last
-  end
-
-  def today
-    Time.current.to_date
+  def daily_goal (user, date=Time.current.to_date)
+    DailyGoal.of(user, date).last
   end
 end

--- a/app/helpers/monthly_goals_helper.rb
+++ b/app/helpers/monthly_goals_helper.rb
@@ -1,22 +1,22 @@
 module MonthlyGoalsHelper
-  def no_monthly_goal? (user)
-    MonthlyGoal.of(user).count.zero?
+  def no_monthly_goal? (user, date=Time.current.to_date)
+    MonthlyGoal.of(user, season_start(date)).count.zero?
   end
 
-  def monthly_goal (user)
-    MonthlyGoal.of(user).last
+  def monthly_goal (user, date=Time.current.to_date)
+    MonthlyGoal.of(user, season_start(date)).last
   end
 
-  def current_season
-    date = Time.current.to_date.beginning_of_month
-    wnum_today = Time.current.to_date.strftime("%W").to_i
-    wnum_beginning = date.strftime("%W").to_i
+  def season_start (date)
+    season_start = date.beginning_of_month
+    wnum_today = date.strftime("%W").to_i
+    wnum_beginning = season_start.strftime("%W").to_i
 
-    if date.wday != 1 and wnum_today - wnum_beginning == 0
-      date = date.prev_month
+    if season_start.wday != 1 and wnum_today - wnum_beginning == 0
+      season_start = season_start.prev_month
     end
 
-    date += 1 until date.wday == 1
-    return date
+    season_start += 1 until season_start.wday == 1
+    return season_start
   end
 end

--- a/app/helpers/weekly_goals_helper.rb
+++ b/app/helpers/weekly_goals_helper.rb
@@ -1,17 +1,14 @@
 module WeeklyGoalsHelper
-  def no_weekly_goal? (user)
-    WeeklyGoal.of(user).count.zero?
+  def no_weekly_goal? (user, date=Time.current.to_date)
+    WeeklyGoal.of(user, date.beginning_of_week).count.zero?
   end
 
-  def weekly_goal (user)
-    WeeklyGoal.of(user).last
+  def weekly_goal (user, date=Time.current.to_date)
+    WeeklyGoal.of(user, date.beginning_of_week).last
   end
 
-  def relative_weeknum
-    Time.current.to_date.strftime("%W").to_i - current_season.strftime("%W").to_i + 1
-  end
-
-  def absolute_weeknum
-    Time.current.to_date.beginning_of_week
-  end
+  # TO BE MODIFIED
+  # def relative_weeknum (date=Time.current.to_date)
+  #   Time.current.to_date.strftime("%W").to_i - current_season.strftime("%W").to_i + 1
+  # end
 end

--- a/app/models/daily_goal.rb
+++ b/app/models/daily_goal.rb
@@ -4,5 +4,5 @@ class DailyGoal < ActiveRecord::Base
   validates :description, presence: true
   validates :goal_date, presence: true
 
-  scope :of, -> (user) { where(user_id: user.id, goal_date: DailyGoalsController.helpers.today) }
+  scope :of, -> (user, date) { where(user_id: user.id, goal_date: date) }
 end

--- a/app/models/monthly_goal.rb
+++ b/app/models/monthly_goal.rb
@@ -4,5 +4,5 @@ class MonthlyGoal < ActiveRecord::Base
   validates :description, presence: true
   validates :season, presence: true
 
-  scope :of, -> (user) { where(user_id: user.id, season: MonthlyGoalsController.helpers.current_season) }
+  scope :of, -> (user, season) { where(user_id: user.id, season: season) }
 end

--- a/app/models/weekly_goal.rb
+++ b/app/models/weekly_goal.rb
@@ -4,5 +4,5 @@ class WeeklyGoal < ActiveRecord::Base
   validates :description, presence: true
   validates :weeknum, presence: true
 
-  scope :of, -> (user) { where(user_id: user.id, weeknum: WeeklyGoalsController.helpers.absolute_weeknum) }
+  scope :of, -> (user, date) { where(user_id: user.id, weeknum: date) }
 end

--- a/app/views/statuses/_status.html.slim
+++ b/app/views/statuses/_status.html.slim
@@ -4,9 +4,9 @@
   - else
     = image_tag "havit-logo-big.jpg"
 = content_for :card_goals, flush:true do
-  p = monthly_goal(status.user).description unless no_monthly_goal?(status.user)
-  p = weekly_goal(status.user).description unless no_weekly_goal?(status.user)
-  p = daily_goal(status.user).description unless no_daily_goal?(status.user)
+  p = monthly_goal(status.user, status.verified_at).description unless no_monthly_goal?(status.user, status.verified_at)
+  p = weekly_goal(status.user, status.verified_at).description unless no_weekly_goal?(status.user, status.verified_at)
+  p = daily_goal(status.user, status.verified_at).description unless no_daily_goal?(status.user, status.verified_at)
 = content_for :card_message, flush:true do
   p.description == status.description
   span.name


### PR DESCRIPTION
지난 시즌, 지난 주, 어제 올린 인증은 그 시즌, 그 주, 어제에 맞는 목표가 보이게 했다.
goal 관련 헬퍼에 date도 파라미터로 넣어서 해당 스테이터스의 verified_at에 맞는 목표가 보이게 만들고, 컨트롤러와 모델도 그에 따라 변경했다.
헬퍼의 date 파라미터는 default로 '오늘'을 넣게 해서 기존의 다른 코드들의 불필요한 수정을 없앴다.
