### PR TITLE
modify-auth-view

### DIFF
--- a/app/assets/stylesheets/statuses.css.scss
+++ b/app/assets/stylesheets/statuses.css.scss
@@ -102,3 +102,25 @@
     color:green;
   }
 }
+
+.auth-user-text {
+  margin-left: 45px;
+}
+
+.new-status-form > .form-group {
+  margin-top : 23px;
+}
+
+.auth-button {
+  margin: 5px;
+  float: right;
+}
+
+.photo-upload {
+  margin: 5px;
+  float: right;
+}
+
+.form-control {
+  color :green !important;
+}

--- a/app/views/statuses/_new.html.slim
+++ b/app/views/statuses/_new.html.slim
@@ -1,9 +1,14 @@
 = form_tag "/statuses", method: "post", multipart: true, class: "new-status-form"
   .status-author.new
     = image_tag(current_user.gravatar_url)
-    span #{current_user.name}님의 #{datestring} #{weekdaystring} 실천
+    span.auth-user-text #{current_user.name}님의 
+    = date_field_tag 'status[verified_at]', Time.current.to_date
+    span.auth-text  실천
+    / span.auth-text #{datestring} #{weekdaystring} 실천
+
   .form-group
     = text_area_tag 'status[description]', nil, placeholder: "#{datestring} #{weekdaystring}: \"#{daily_goal.description}\" 인증하기", required: true, class: 'form-control'
-    = file_field_tag 'status[photo]', accept: 'image/png,image/gif,image/jpeg'
-    = date_field_tag 'status[verified_at]', Time.current.to_date
-    = submit_tag "등록", class: 'btn btn-primary btn-sm submit-btn'
+    .file-and-submit
+      = submit_tag "등록", class: 'btn btn-primary btn-sm submit-btn auth-button'
+      = file_field_tag 'status[photo]', accept: 'image/png,image/gif,image/jpeg', class: 'photo-upload'
+      


### PR DESCRIPTION
- '사진 파일 업로드' 부분과 '등록' 부분을 한 줄에 오게 하고, 오른쪽으로 정렬되게 함.
- '2015년 3월 27일 금요일에 실천' 부분을 지우고, date_field_tag 를 추가함. 이를 구현하기 위해, _new.html.slim에서 이 부분의 텍스트를 따로 떨어뜨림.
- margin 세부 조정.
- 목표를 placeholder가 아닌 오른쪽 윗부분에 넣으면 특히 목표가 길어졌을 때 이상해 보일 것 같아서 그대로 놔둠.
